### PR TITLE
Update chandler_ship.gd

### DIFF
--- a/scripts/enemy/classic_world/ships/chandler_ship.gd
+++ b/scripts/enemy/classic_world/ships/chandler_ship.gd
@@ -1,26 +1,56 @@
 extends Node2D
-const spawnable_drop1 = preload("res://scenes/enemy/classic_world/drops/recycle_drop.tscn")
-const spawnable_drop2 = preload("res://scenes/enemy/classic_world/drops/trash_drop.tscn")
-#const spawnable_drop2 = preload("res://scenes/enemy/heart_drop.tscn")
-@onready var animated_sprite : AnimatedSprite2D = get_node("AnimatedSprite2D")
-@onready var ship_component  : Node2D           = get_node("ship_component")
-@onready var wait_timer      : Timer            = get_node("ship_component/wait_timer")
-var parent_score : int
+
+# Use uppercase constant naming for clarity
+const SPAWNABLE_DROP_1 = preload("res://scenes/enemy/classic_world/drops/recycle_drop.tscn")
+const SPAWNABLE_DROP_2 = preload("res://scenes/enemy/classic_world/drops/trash_drop.tscn")
+# Example alternative drop: const SPAWNABLE_DROP_ALT = preload("res://scenes/enemy/heart_drop.tscn")
+
+@onready var animated_sprite: AnimatedSprite2D = $AnimatedSprite2D
+@onready var ship_component: Node2D = $ship_component
+@onready var wait_timer: Timer      = $ship_component/wait_timer
+
+var parent_score: int
+
 func _ready() -> void:
-	parent_score = get_parent().score
-	# as the game goes on, the chandler ship will drop less and less point trash, this is counteracted since there will be more of them
-	match parent_score / 20:
-		0:
-			ship_component.counter += randi() % 6
-		1:
-			ship_component.counter += randi() % 5
-		2:
-			ship_component.counter += randi() % 4
-		3:
-			ship_component.counter += randi() % 3
-		_: 
-			ship_component.counter += randi() % 2
-	
-	animated_sprite.play("default")
-	ship_component.speed += randi() % 55
-	wait_timer.wait_time = randi() % 2 + ship_component.wait_time
+    # Randomize the engine's global seed to ensure more varied results at runtime.
+    # If the rest of your game already calls randomize(), you can remove this line.
+    randomize()
+
+    # Retrieve the parent node's "score". If it's a script with a 'score' property,
+    # ensure that property is accessible.
+    parent_score = get_parent().score
+
+    # Example logic: As the game progresses (score grows), the ship drops fewer points.
+    # We use match to clamp ship_component.counter increments.
+    match int(parent_score / 20):
+        0:
+            ship_component.counter += randi() % 6
+        1:
+            ship_component.counter += randi() % 5
+        2:
+            ship_component.counter += randi() % 4
+        3:
+            ship_component.counter += randi() % 3
+        _:
+            ship_component.counter += randi() % 2
+
+    # Start the default animation for the sprite
+    animated_sprite.play("default")
+
+    # Increase the ship's speed by a random offset up to 54
+    ship_component.speed += randi() % 55
+
+    # Adjust the timer's wait_time by a random factor
+    wait_timer.wait_time = (randi() % 2) + ship_component.wait_time
+
+    # Optionally, you could spawn a random drop on start for testing:
+    # spawn_drop_random()
+
+# Example function: spawn a random drop from the preloaded scenes
+func spawn_drop_random() -> void:
+    var use_alternate_drop: bool = bool(randi() % 2)
+    var drop_scene: PackedScene = use_alternate_drop ? SPAWNABLE_DROP_2 : SPAWNABLE_DROP_1
+
+    var drop_instance: Node2D = drop_scene.instantiate()
+    drop_instance.position = position + Vector2(randi() % 32 - 16, randi() % 32 - 16)
+    get_parent().add_child(drop_instance)


### PR DESCRIPTION
Explanation & Enhancements
Renamed Constants

SPAWNABLE_DROP_1 and SPAWNABLE_DROP_2 are now uppercase to follow the typical GDScript convention for constants. Typed Variables

We specify @onready var animated_sprite: AnimatedSprite2D = $AnimatedSprite2D, etc., for clarity. var parent_score: int ensures we track that property as an integer. Randomization

Added a call to randomize() in _ready() so each run is less predictable. If you call randomize() globally elsewhere, you can remove it here. The code uses randi() % 6, etc., for random increments. If you prefer a more robust approach, consider RandomNumberGenerator. Optional Drop Spawning

Added a sample function spawn_drop_random() that picks randomly between SPAWNABLE_DROP_1 and SPAWNABLE_DROP_2. Adjust as needed. Better Indentation & Comments

The code is better structured and commented, so it’s easier for future you or other devs to maintain. Use of $NodeName

Godot 4 allows $AnimatedSprite2D instead of get_node("AnimatedSprite2D"). If you’re on Godot 3.x, you can keep get_node. Feel free to tailor the random logic, naming, or extra functions to match your project’s design and code style.